### PR TITLE
JUnit4 Tests should not extend Junit3's TestCase class

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ can be read from your unit tests, which lets you test this widget as follows:
 
 ```java
 @RunWith(GwtMockitoTestRunner.class)
-public class MyWidgetTest extends TestCase {
+public class MyWidgetTest {
 
   @Mock NumberFormatter formatter;
   private MyWidget widget;


### PR DESCRIPTION
In the readme a JUnit4 test extends JUnit3's TestCase class. This should be avoided.
In the actual samples this is not the case
