### PR TITLE
@GwtMock is not initialized for parent class members

### DIFF
--- a/gwtmockito/src/test/java/com/google/gwtmockito/GwtMockInheritanceTest.java
+++ b/gwtmockito/src/test/java/com/google/gwtmockito/GwtMockInheritanceTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2013 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.gwtmockito;
+
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Test;
+
+/**
+ * Tests behavior of {@link GwtMock} in a super class.
+ */
+public class GwtMockInheritanceTest extends GwtMockInheritanceTestBase {
+
+  @Test
+  public void shouldInitInheritedGwtMocks() {
+    assertNotNull(mockedSuperMember);
+  }
+
+}

--- a/gwtmockito/src/test/java/com/google/gwtmockito/GwtMockInheritanceTestBase.java
+++ b/gwtmockito/src/test/java/com/google/gwtmockito/GwtMockInheritanceTestBase.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2013 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.gwtmockito;
+
+import org.junit.runner.RunWith;
+
+/**
+ * Base class for {@link GwtMockInheritanceTest}.
+ */
+@RunWith(GwtMockitoTestRunner.class)
+public class GwtMockInheritanceTestBase {
+  @GwtMock protected SampleInterface mockedSuperMember;
+
+  protected static interface SampleInterface {
+    String doSomething();
+  }
+
+}


### PR DESCRIPTION
For test groups that share common setup() and member variables, it is useful to define a base class that includes common mocks, to avoid boilerplate. Mockito supports this for `@Mock`. GwtMockito can support it with this small modification.
