### PR TITLE
async callback arg choosing bug fix

### DIFF
--- a/gwtmockito/src/main/java/com/google/gwtmockito/AsyncAnswers.java
+++ b/gwtmockito/src/main/java/com/google/gwtmockito/AsyncAnswers.java
@@ -43,7 +43,7 @@ public class AsyncAnswers {
       public Void answer(InvocationOnMock invocation) {
         for (Object arg : invocation.getArguments()) {
           if (arg instanceof AsyncCallback<?>) {
-            ((AsyncCallback<T>) invocation.getArguments()[1]).onSuccess(result);
+            ((AsyncCallback<T>) arg).onSuccess(result);
             return null;
           }
         }
@@ -67,7 +67,7 @@ public class AsyncAnswers {
       public Void answer(InvocationOnMock invocation) {
         for (Object arg : invocation.getArguments()) {
           if (arg instanceof AsyncCallback<?>) {
-            ((AsyncCallback<?>) invocation.getArguments()[1]).onFailure(result);
+            ((AsyncCallback<?>) arg).onFailure(result);
             return null;
           }
         }

--- a/gwtmockito/src/test/java/com/google/gwtmockito/rpc/GwtMockitoRpcTest.java
+++ b/gwtmockito/src/test/java/com/google/gwtmockito/rpc/GwtMockitoRpcTest.java
@@ -56,6 +56,25 @@ public class GwtMockitoRpcTest {
     }
   }
 
+  private static class MyWidgetWithoutArgs {
+    @UiField HasText message = GWT.create(Label.class);
+    private final TestRemoteServiceAsync service = GWT.create(TestRemoteService.class);
+
+    MyWidgetWithoutArgs() {
+      service.doRpcWithoutArgs(new AsyncCallback<String>() {
+        @Override
+        public void onSuccess(String result) {
+          message.setText(result);
+        }
+
+        @Override
+        public void onFailure(Throwable caught) {
+          message.setText(caught.getMessage());
+        }
+      });
+    }
+  }
+
   @GwtMock TestRemoteServiceAsync service;
 
   @Test
@@ -76,6 +95,28 @@ public class GwtMockitoRpcTest {
         .when(service).doRpc(any(String.class), any(AsyncCallback.class));
 
     MyWidget widget = new MyWidget();
+
+    verify(widget.message).setText("error!");
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void shouldAllowStubbedRpcSuccessWithoutArgs() throws Exception {
+    doAnswer(returnSuccess("success!"))
+        .when(service).doRpcWithoutArgs(any(AsyncCallback.class));
+
+    MyWidgetWithoutArgs widget = new MyWidgetWithoutArgs();
+
+    verify(widget.message).setText("success!");
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void shouldAllowStubbedRpcFailureWithoutArgs() throws Exception {
+    doAnswer(returnFailure(new IllegalArgumentException("error!")))
+        .when(service).doRpcWithoutArgs(any(AsyncCallback.class));
+
+    MyWidgetWithoutArgs widget = new MyWidgetWithoutArgs();
 
     verify(widget.message).setText("error!");
   }

--- a/gwtmockito/src/test/java/com/google/gwtmockito/rpc/TestRemoteService.java
+++ b/gwtmockito/src/test/java/com/google/gwtmockito/rpc/TestRemoteService.java
@@ -19,4 +19,5 @@ import com.google.gwt.user.client.rpc.RemoteService;
 
 public interface TestRemoteService extends RemoteService {
   String doRpc(String arg);
+  String doRpcWithoutArgs();
 }

--- a/gwtmockito/src/test/java/com/google/gwtmockito/rpc/TestRemoteServiceAsync.java
+++ b/gwtmockito/src/test/java/com/google/gwtmockito/rpc/TestRemoteServiceAsync.java
@@ -19,4 +19,5 @@ import com.google.gwt.user.client.rpc.AsyncCallback;
 
 public interface TestRemoteServiceAsync {
   void doRpc(String arg, AsyncCallback<String> callback);
+  void doRpcWithoutArgs(AsyncCallback<String> callback);
 }


### PR DESCRIPTION
Thix PR solves problem with wrong arg chosen (always second one) for `AsyncAnswers#returnSuccess` and `AsyncAnswers#returnFailure` methods
