### PR TITLE
Try to use exact type provider first.

### DIFF
--- a/gwtmockito/src/main/java/com/google/gwtmockito/GwtMockito.java
+++ b/gwtmockito/src/main/java/com/google/gwtmockito/GwtMockito.java
@@ -220,6 +220,13 @@ public class GwtMockito {
         return (T) registeredMocks.get(type);
       }
 
+      // Then check for the exact type provider.
+      if (registeredProviders.containsKey(type)) {
+          // Its safe - it's the same type provider
+          @SuppressWarnings({"rawtypes", "cast"})
+          return (T) entry.getValue().getFake(type);
+      }
+
       // Next see if we have a provider for this type or a supertype.
       for (Entry<Class<?>, FakeProvider<?>> entry : registeredProviders.entrySet()) {
         if (entry.getKey().isAssignableFrom(type)) {


### PR DESCRIPTION
Hello,

I've got an issue with the current provider resolving behavior:

I registered a provider for MyMessages.class which extends com.google.gwt.i18n.client.Messages.class, and now attempt to get MyMessages mock gives me MyMessages or Messages depending on luck and hashCodes, because there is already a default provider for Messages.

Using exact type provider if you've got one would be nice. 
