### PR TITLE
Add support for JUnit 4.12 private field rename

### DIFF
--- a/gwtmockito/src/main/java/com/google/gwtmockito/GwtMockitoTestRunner.java
+++ b/gwtmockito/src/main/java/com/google/gwtmockito/GwtMockitoTestRunner.java
@@ -142,8 +142,13 @@ public class GwtMockitoTestRunner extends BlockJUnit4ClassRunner {
 
       // Overwrite the private "fTestClass" field in ParentRunner (superclass of
       // BlockJUnit4ClassRunner). This refers to the test class being run, so replace it with our
-      // custom-loaded class.
-      Field testClassField = ParentRunner.class.getDeclaredField("fTestClass");
+      // custom-loaded class. As of JUnit 4.12, "fTestClass" was renamed to "testClass".
+      Field testClassField;
+      try {
+        testClassField = ParentRunner.class.getDeclaredField("fTestClass");
+      } catch (NoSuchFieldException e) {
+        testClassField = ParentRunner.class.getDeclaredField("testClass");
+      }
       testClassField.setAccessible(true);
       testClassField.set(this, new TestClass(customLoadedTestClass));
     } catch (Exception e) {


### PR DESCRIPTION
As part of [this JUnit commit](https://github.com/junit-team/junit/commit/df00d5eced3a7737b88de0f6f9e3673f0cf88f88), the private field `fTestClass` was renamed to `testClass`. I found a related discussion [here](https://github.com/junit-team/junit/issues/960).

This fix should add support for using gwtmockito with JUnit 4.12+. 
