### PR TITLE
Use mockito-core instead of mockito-all which is uberjar

### DIFF
--- a/gwtmockito-sample/pom.xml
+++ b/gwtmockito-sample/pom.xml
@@ -23,7 +23,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/gwtmockito/pom.xml
+++ b/gwtmockito/pom.xml
@@ -29,7 +29,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <artifactId>mockito-core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.javassist</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>
-        <artifactId>mockito-all</artifactId>
+        <artifactId>mockito-core</artifactId>
         <version>1.9.5</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
 * mockito-all is uberjar which bundles all transitive
   deps (hamcrest-core and objenesis) into single jar . This is bad,
   becuase it disrupts Maven based dependency management. Projects
   using gwtmockito may require different version of
   hamcrest-core than the one bundled in mockito-all. That will
   result in hamcrest-core classes being twice on classpath
   without any guarantee which one will be loaded first. That
   leads to very hard to debug issues.