### PR TITLE
Upgrade mockito 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .project
 .settings
 target/
+.idea/
+*.iml

--- a/gwtmockito/pom.xml
+++ b/gwtmockito/pom.xml
@@ -41,7 +41,7 @@
          https://github.com/google/gwtmockito/issues/14. -->
     <dependency>
       <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito</artifactId>
+      <artifactId>powermock-api-mockito2</artifactId>
     </dependency>
 
   </dependencies>

--- a/gwtmockito/src/test/java/com/google/gwtmockito/GwtMockitoTest.java
+++ b/gwtmockito/src/test/java/com/google/gwtmockito/GwtMockitoTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 
 import com.google.gwt.cell.client.AbstractCell;
 import com.google.gwt.core.client.JavaScriptObject;
@@ -357,7 +358,7 @@ public class GwtMockitoTest {
   @Test
   public void shouldAllowArgumentMatchers() throws Exception {
     element.setClassName("classname");
-    verify(element).setClassName(Matchers.argThat(new BaseMatcher<String>() {
+    verify(element).setClassName(argThat(new BaseMatcher<String>() {
       @Override
       public boolean matches(Object item) {
         return item.toString().equals("classname");

--- a/gwtmockito/src/test/java/com/google/gwtmockito/GwtMockitoTest.java
+++ b/gwtmockito/src/test/java/com/google/gwtmockito/GwtMockitoTest.java
@@ -18,6 +18,7 @@ package com.google.gwtmockito;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -70,6 +71,7 @@ import com.google.gwt.user.client.ui.HTML;
 import com.google.gwt.user.client.ui.Image;
 import com.google.gwt.user.client.ui.InlineHTML;
 import com.google.gwt.user.client.ui.InlineLabel;
+import com.google.gwt.user.client.ui.IntegerBox;
 import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.ListBox;
 import com.google.gwt.user.client.ui.RadioButton;
@@ -690,6 +692,13 @@ public class GwtMockitoTest {
   }
 
   @Test
+  public void testIntegerBox() {
+    SampleWidget widget = new SampleWidget();
+
+    when(widget.intbox.getValue()).thenReturn(null);
+  }
+
+  @Test
   @SuppressWarnings("unused")
   public void shouldBeAbleToCreateValueListBox() {
     new ValueListBox<Object>();
@@ -757,6 +766,7 @@ public class GwtMockitoTest {
 
     @UiField Label label;
     @UiField SampleCss css;
+    @UiField IntegerBox intbox;
 
     SampleWidget() {
       MyUiBinder uiBinder = GWT.create(MyUiBinder.class);

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
-        <version>1.10.19</version>
+        <version>2.24.0</version>
       </dependency>
       <dependency>
         <groupId>org.javassist</groupId>
@@ -86,8 +86,8 @@
            https://github.com/google/gwtmockito/issues/14. -->
       <dependency>
         <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito</artifactId>
-      <version>1.6.6</version>
+      <artifactId>powermock-api-mockito2</artifactId>
+      <version>2.0.0</version>
       <scope>test</scope>
       </dependency>
     </dependencies>


### PR DESCRIPTION
This particular test fails with the following exception:

```java
testIntegerBox(com.google.gwtmockito.GwtMockitoTest)  Time elapsed: 0.006 sec  <<< ERROR!
java.lang.ClassCastException: org.mockito.codegenObject$MockitoMock$1927715379 cannot be cast to java.lang.Integer
	at com.google.gwt.user.client.ui.IntegerBox$MockitoMock$87819473.getValue(Unknown Source)
	at com.google.gwt.user.client.ui.IntegerBox$MockitoMock$87819473.getValue(Unknown Source)
	at com.google.gwtmockito.GwtMockitoTest.testIntegerBox(GwtMockitoTest.java:698)
```