### PR TITLE
Allow ResourcePrototype methods in fake ClientBundle

### DIFF
--- a/gwtmockito/src/main/java/com/google/gwtmockito/fakes/FakeClientBundleProvider.java
+++ b/gwtmockito/src/main/java/com/google/gwtmockito/fakes/FakeClientBundleProvider.java
@@ -97,6 +97,9 @@ public class FakeClientBundleProvider implements FakeProvider<ClientBundle> {
               ((ResourceCallback<ResourcePrototype>) args[0]).onSuccess(
                   (ResourcePrototype) createFakeResource(resourceType, name));
               return null;
+            } else if (returnType.isInstance(proxy)) {
+              // for custom methods producing ResourcePrototype
+              return proxy;
             } else {
               throw new IllegalArgumentException(
                   "Unexpected return type for method " + method.getName());

--- a/gwtmockito/src/main/java/com/google/gwtmockito/fakes/FakeClientBundleProvider.java
+++ b/gwtmockito/src/main/java/com/google/gwtmockito/fakes/FakeClientBundleProvider.java
@@ -87,7 +87,8 @@ public class FakeClientBundleProvider implements FakeProvider<ClientBundle> {
               return false;
             } else if (returnType == int.class) {
               return 0;
-            } else if (method.getParameterTypes()[0] == ResourceCallback.class) {
+            } else if (method.getParameterTypes().length > 0
+                && method.getParameterTypes()[0] == ResourceCallback.class) {
               // Read the underlying resource type out of the generic parameter
               // in the method's argument
               Class<?> resourceType = 

--- a/gwtmockito/src/test/java/com/google/gwtmockito/GwtMockitoTest.java
+++ b/gwtmockito/src/test/java/com/google/gwtmockito/GwtMockitoTest.java
@@ -412,6 +412,12 @@ public class GwtMockitoTest {
     assertEquals("externalText", result.toString());
   }
 
+  @Test
+  public void shouldMockCustomClientBundles() throws Exception {
+    SvgClientBundle clientBundle = GWT.create(SvgClientBundle.class);
+    assertTrue(clientBundle.icon().transform() instanceof DataResource);
+  }
+
   /**
    * This would fail if we didn't stub the create methods from DOM. See
    * https://github.com/google/gwtmockito/issues/4.
@@ -744,6 +750,14 @@ public class GwtMockitoTest {
     ExternalTextResource externalText();
     ImageResource image();
     TextResource text();
+  }
+
+  interface SvgResource extends DataResource {
+    SvgResource transform();
+  }
+
+  interface SvgClientBundle extends ClientBundle {
+    SvgResource icon();
   }
 
   enum SomeEnum {


### PR DESCRIPTION
This PR allows you to mock ResourcePrototypes that have a method producing another ResourcePrototype (usecase: SVGResource that can produce SVGs in different colors)