### PR TITLE
Fix javassist 3.26.0-GA

### DIFF
--- a/gwtmockito/src/main/java/com/google/gwtmockito/GwtMockitoTestRunner.java
+++ b/gwtmockito/src/main/java/com/google/gwtmockito/GwtMockitoTestRunner.java
@@ -24,6 +24,7 @@ import javassist.Loader;
 import javassist.LoaderClassPath;
 import javassist.NotFoundException;
 import javassist.Translator;
+import javassist.bytecode.AccessFlag;
 
 import com.google.gwt.user.cellview.client.CellList;
 import com.google.gwt.user.cellview.client.CellTable;
@@ -433,8 +434,9 @@ public class GwtMockitoTestRunner extends BlockJUnit4ClassRunner {
         throws NotFoundException, CannotCompileException {
       CtClass clazz = pool.get(name);
 
-      // Strip final modifiers from the class and all methods to allow them to be mocked
-      clazz.getClassFile().setAccessFlags(clazz.getModifiers() & ~Modifier.FINAL);
+      // Strip final accessFlag from the class and all methods to allow them to be mocked
+      clazz.getClassFile().setAccessFlags(clazz.getClassFile().getAccessFlags() & ~AccessFlag.FINAL);
+      
       for (CtMethod method : clazz.getDeclaredMethods()) {
         method.setModifiers(method.getModifiers() & ~Modifier.FINAL);
       }

--- a/gwtmockito/src/main/java/com/google/gwtmockito/GwtMockitoTestRunner.java
+++ b/gwtmockito/src/main/java/com/google/gwtmockito/GwtMockitoTestRunner.java
@@ -436,7 +436,6 @@ public class GwtMockitoTestRunner extends BlockJUnit4ClassRunner {
 
       // Strip final accessFlag from the class and all methods to allow them to be mocked
       clazz.getClassFile().setAccessFlags(clazz.getClassFile().getAccessFlags() & ~AccessFlag.FINAL);
-      
       for (CtMethod method : clazz.getDeclaredMethods()) {
         method.setModifiers(method.getModifiers() & ~Modifier.FINAL);
       }


### PR DESCRIPTION
So two things that are happening here:
1) `clazz.getClassFile().setAccessFlags(clazz.getModifiers() & ~Modifier.FINAL)` is invalid since the modifiers have different info/flags than the `accessFlag` and then this trips java/javassist.

For instance for a final enum class inside a static inner class:

```
0x4019 ctClass.getModifiers()
  ENUM, FINAL, STATIC, PUBLIC
0x4009 ctClass.getModifiers() & ~Modifiers.FINAL
  ENUM, FINAL, STATIC, PUBLIC

0x4031 ctClass.getClassFile().getAccessFlags()
  ENUM, FINAL, SYNCHRONIZED, PUBLIC
0x4021 ctClass.getClassFile().getAccessFlags() & ~Modifiers.FINAL
  ENUM, SYNCHRONIZED, PUBLIC
0x4021 ctClass.getClassFile().getAccessFlags() & ~AccessFlags.FINAL
  ENUM, SYNCHRONIZED, PUBLIC
```

This leaves us with 2).

2) We can't use `clazz.setModifiers(clazz.getModifiers() & ~Modifiers.FINAL)` because it will try to update the inner classes of the class and this might trigger an exception if an inner CtClass was already loaded and frozen.

The reason it tries to update the inner classes is because it detects that the STATIC flag might have changed and this needs to be propagated to all inner classes, even if no change was needed!
